### PR TITLE
README and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ required arguments:
                         unstitched_locus-unstitched_pos. FREQ columns from VarScan are also
                         assumed.
   -o OUTDIR, --outdir OUTDIR
-                        /path/to/pypoolation_output_dir/
+                        /path/to/cmh_test_output_dir/
+                        File output from cmh_test.py will be saved in the outdir, with the original
+                        name of the input file, but with the suffix "_CMH-test-results.txt"
   --case CASE           The string present in every column for pools in "case" treatments.
   --control CONTROL     The string present in every column for pools in "control" treatments.
   -p PLOIDYFILE, --ploidy PLOIDYFILE

--- a/cmh_test.py
+++ b/cmh_test.py
@@ -414,8 +414,11 @@ will prompt for pool_name if necessary.''')
 
     # if input or ploidy file do not exist:
     if len(nopath) > 0:
-        print(ColorText("FAIL: The following path%s do not exist:" % "s" if len(nopath) > 1 else "").fail())
-        [print(ColorText("\nFAIL: %s" % f).fail()) for f in nopath]
+        print(ColorText("FAIL: The following path(s) do not exist:").fail())
+        for f in nopath:
+            print(ColorText("\tFAIL: %s" % f).fail())
+        print(ColorText('\nexiting cmh_test.py').fail())
+        exit()
     
     print('args = ', args)
     return args


### PR DESCRIPTION
Added `exit()` after failed assumption. Updated usage description of README.