### PR TITLE
skip loci that have all contingency tables each fixed for REF or ALT

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # cmh_test
 Using ipcluster engines to parallelize calculations from [varscan_pipeline](https://github.com/CoAdapTree/varscan_pipeline) outfiles, calculate Cochran-Mantel-Haenszel chi-squared tests on stratified contingency tables.
 
-Each stratum is a pool. Each contingency table is 2x2 - case and control x REF and ALT allele counts.
+Each stratum is a population. Each population has a "case" pool and a "control" pool. Together, these case and control pools make the contingency table. Each contingency table is 2x2 - case and control x REF and ALT allele counts.
 
 ALT and REF allele counts are calculated by multiplying the ploidy of the pool by ...
 ... either the ALT freq or (1-ALT_freq).

--- a/cmh_test.py
+++ b/cmh_test.py
@@ -292,7 +292,7 @@ def create_tables(*args):
 
 def cmh_test(*args):
     """Perform Cochran-Mantel-Haenszel chi-squared test on stratified contingency tables."""
-    import pandas
+    import pandas, math
     from statsmodels.stats.contingency_tables import StratifiedTable as cmh
     
     tables = create_tables(*args)
@@ -322,7 +322,7 @@ def cmh_test(*args):
 
             # when I've observed this happen, the following are true
             assert res.statistic == math.inf
-            assert cmh_res.oddsratio_pooled_confint() != cmh_res.oddsratio_pooled_confint()  # np.nans
+            assert sum([math.isnan(x) for x in conf]) == 2  # np.nans ie (nan, nan)
 
             continue
         results.loc[len(results.index), :] = (locus, odds_ratio, res.pvalue, *conf, len(table))


### PR DESCRIPTION
This can happen when all of the tables returned for a specific locus are fixed for either the REF or ALT. This happens rarely for loci with low MAF, where the populations that have polymorphisms in either case or control, do not have a frequency estimated for the other treatment (case or control) and therefore don't make it into the list of stratified tables. The remaining tables (populations) that make it into the stratified tables can some times all be fixed for the REF or ALT - again, this happens for some low MAF loci and may happen if input file has few pops to stratify.

To prevent this issue, just skip loci with such features. Beforehand, the code would return a p-value of 0 and np.nan for the odds ratio and its upper/lower confidence interval.

The conditions were addressed, and loci meeting these conditions will be excluded from output.